### PR TITLE
Use norm_whitespace everywhere

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,8 @@ let src_code = ipl.generate();
 println!("{}", &src_code);
 
 assert_eq!(
-    normalize_whitespace(expected),
-    normalize_whitespace(&src_code)
+    norm_whitespace(expected),
+    norm_whitespace(&src_code)
 )
 ```
 

--- a/tests/function_gen_test.rs
+++ b/tests/function_gen_test.rs
@@ -1,12 +1,5 @@
 use proffer::*;
 
-fn normalize_whitespace(s: &str) -> String {
-    s.split("\n")
-        .map(|l| l.trim())
-        .filter(|l| l.len() > 0)
-        .collect::<String>()
-}
-
 #[test]
 fn function_gen_basic() {
     let function = Function::new("foo");
@@ -20,8 +13,8 @@ fn function_gen_basic() {
     let src_code = function.generate();
     println!("{}", &src_code);
     assert_eq!(
-        normalize_whitespace(expected),
-        normalize_whitespace(&src_code)
+        norm_whitespace(expected),
+        norm_whitespace(&src_code)
     );
 }
 
@@ -41,8 +34,8 @@ fn function_gen_parameters() {
     let src_code = function.generate();
     println!("{}", &src_code);
     assert_eq!(
-        normalize_whitespace(expected),
-        normalize_whitespace(&src_code)
+        norm_whitespace(expected),
+        norm_whitespace(&src_code)
     );
 }
 
@@ -75,8 +68,8 @@ fn function_with_generic() {
     let src_code = function.generate();
     println!("{}", &src_code);
     assert_eq!(
-        normalize_whitespace(expected),
-        normalize_whitespace(&src_code)
+        norm_whitespace(expected),
+        norm_whitespace(&src_code)
     );
 }
 
@@ -101,8 +94,8 @@ fn function_with_generic_no_bounds() {
     let src_code = function.generate();
     println!("{}", &src_code);
     assert_eq!(
-        normalize_whitespace(expected),
-        normalize_whitespace(&src_code)
+        norm_whitespace(expected),
+        norm_whitespace(&src_code)
     );
 }
 
@@ -122,7 +115,7 @@ fn function_with_async() {
     let src_code = function.generate();
     println!("{}", &src_code);
     assert_eq!(
-        normalize_whitespace(expected),
-        normalize_whitespace(&src_code)
+        norm_whitespace(expected),
+        norm_whitespace(&src_code)
     );
 }

--- a/tests/impl_gen_test.rs
+++ b/tests/impl_gen_test.rs
@@ -1,12 +1,5 @@
 use proffer::*;
 
-fn normalize_whitespace(s: &str) -> String {
-    s.split("\n")
-        .map(|l| l.trim())
-        .filter(|l| l.len() > 0)
-        .collect::<String>()
-}
-
 #[test]
 fn impl_basic_gen_with_trait() {
     let mut ipl = Impl::new("That")
@@ -22,8 +15,8 @@ fn impl_basic_gen_with_trait() {
     println!("{}", &src_code);
 
     assert_eq!(
-        normalize_whitespace(expected),
-        normalize_whitespace(&src_code)
+        norm_whitespace(expected),
+        norm_whitespace(&src_code)
     );
 
     // Add a function to the impl
@@ -42,8 +35,8 @@ fn impl_basic_gen_with_trait() {
     println!("{}", &src_code);
 
     assert_eq!(
-        normalize_whitespace(expected),
-        normalize_whitespace(&src_code)
+        norm_whitespace(expected),
+        norm_whitespace(&src_code)
     );
 }
 
@@ -61,8 +54,8 @@ fn impl_basic_gen_without_trait() {
     println!("{}", &src_code);
 
     assert_eq!(
-        normalize_whitespace(expected),
-        normalize_whitespace(&src_code)
+        norm_whitespace(expected),
+        norm_whitespace(&src_code)
     )
 }
 
@@ -104,8 +97,8 @@ fn impl_with_generics() {
     println!("{}", &src_code);
 
     assert_eq!(
-        normalize_whitespace(expected),
-        normalize_whitespace(&src_code)
+        norm_whitespace(expected),
+        norm_whitespace(&src_code)
     )
 }
 
@@ -128,7 +121,7 @@ fn impl_with_associated_types() {
     println!("{}", &src_code);
 
     assert_eq!(
-        normalize_whitespace(expected),
-        normalize_whitespace(&src_code)
+        norm_whitespace(expected),
+        norm_whitespace(&src_code)
     );
 }

--- a/tests/struct_gen_test.rs
+++ b/tests/struct_gen_test.rs
@@ -1,12 +1,5 @@
 use proffer::*;
 
-fn normalize_whitespace(s: &str) -> String {
-    s.split("\n")
-        .map(|l| l.trim())
-        .filter(|l| l.len() > 0)
-        .collect::<String>()
-}
-
 #[test]
 fn basic_gen() {
     let struct_ = Struct::new("Basic")
@@ -35,8 +28,8 @@ fn basic_gen() {
     let src_code = struct_.generate();
     println!("{}", &src_code);
     assert_eq!(
-        normalize_whitespace(&src_code),
-        normalize_whitespace(&expected)
+        norm_whitespace(&src_code),
+        norm_whitespace(&expected)
     );
 }
 
@@ -71,7 +64,7 @@ fn generic_gen() {
     "#;
     let src_code = s.generate();
     assert_eq!(
-        normalize_whitespace(&src_code),
-        normalize_whitespace(&expected)
+        norm_whitespace(&src_code),
+        norm_whitespace(&expected)
     );
 }

--- a/tests/trait_gen_test.rs
+++ b/tests/trait_gen_test.rs
@@ -1,12 +1,5 @@
 use proffer::*;
 
-fn normalize_whitespace(s: &str) -> String {
-    s.split("\n")
-        .map(|l| l.trim())
-        .filter(|l| l.len() > 0)
-        .collect::<String>()
-}
-
 #[test]
 fn basic_gen() {
     let tr8t = Trait::new("Foo").set_is_pub(true).to_owned();
@@ -20,8 +13,8 @@ fn basic_gen() {
     println!("{}", &src_code);
 
     assert_eq!(
-        normalize_whitespace(expected),
-        normalize_whitespace(&src_code)
+        norm_whitespace(expected),
+        norm_whitespace(&src_code)
     );
 }
 
@@ -44,8 +37,8 @@ fn gen_with_method_signatures() {
     println!("{}", &src_code);
 
     assert_eq!(
-        normalize_whitespace(expected),
-        normalize_whitespace(&src_code)
+        norm_whitespace(expected),
+        norm_whitespace(&src_code)
     );
 }
 
@@ -79,8 +72,8 @@ fn gen_with_generics() {
     println!("{}", &src_code);
 
     assert_eq!(
-        normalize_whitespace(expected),
-        normalize_whitespace(&src_code)
+        norm_whitespace(expected),
+        norm_whitespace(&src_code)
     );
 }
 
@@ -109,7 +102,7 @@ fn gen_with_associated_types() {
     println!("{}", &src_code);
 
     assert_eq!(
-        normalize_whitespace(expected),
-        normalize_whitespace(&src_code)
+        norm_whitespace(expected),
+        norm_whitespace(&src_code)
     );
 }


### PR DESCRIPTION
norm_whitespace was implement again as normalize_whitespace in some tests.

Do you want an issue for changes like this?