### PR TITLE
Fix clippy warnings

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,6 +28,11 @@ jobs:
       - run:
           name: Run all tests
           command: cargo test --all
+      - run:
+          name: Run clippy
+          command: |
+              rustup component add clippy
+              cargo clippy --all -- -D warnings
 
 workflows:
   version: 2.1

--- a/src/generics_gen.rs
+++ b/src/generics_gen.rs
@@ -61,7 +61,7 @@ impl Generics {
 
 impl SrcCode for Generics {
     fn generate(&self) -> String {
-        if self.generics.len() > 0 {
+        if !self.generics.is_empty() {
             let template = r#"<{{ generic_keys | join(sep=", ") }}>
                 where
                     {% for generic in generics %}{{ generic.generic }}: {{ generic.traits | join(sep=" + ") }},

--- a/src/impl_gen.rs
+++ b/src/impl_gen.rs
@@ -75,8 +75,7 @@ impl SrcCode for Impl {
             &self
                 .impl_trait
                 .as_ref()
-                .map(|t| t.name.clone())
-                .unwrap_or("".to_string()),
+                .map_or_else(|| "".to_string(), |t| t.name.clone()),
         );
         context.insert("has_generics", &!self.generics.is_empty());
         context.insert("generics", &self.generics.generics);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,9 +71,10 @@ pub use traits::SrcCode;
 
 /// Helper function throughout tests and documentation
 /// for comparing expected source code generated.
+#[must_use]
 pub fn norm_whitespace(s: &str) -> String {
-    s.split("\n")
-        .map(|l| l.trim())
-        .filter(|l| l.len() > 0)
+    s.split('\n')
+        .map(str::trim)
+        .filter(|l| !l.is_empty())
         .collect::<String>()
 }

--- a/src/module_gen.rs
+++ b/src/module_gen.rs
@@ -152,11 +152,11 @@ impl SrcCode for Module {
         ctx.insert("self", &self);
 
         let mut objs: Vec<String> = vec![];
-        &self.traits.iter().for_each(|v| objs.push(v.generate()));
-        &self.functions.iter().for_each(|v| objs.push(v.generate()));
-        &self.structs.iter().for_each(|v| objs.push(v.generate()));
-        &self.impls.iter().for_each(|v| objs.push(v.generate()));
-        &self.enums.iter().for_each(|v| objs.push(v.generate()));
+        self.traits.iter().for_each(|v| objs.push(v.generate()));
+        self.functions.iter().for_each(|v| objs.push(v.generate()));
+        self.structs.iter().for_each(|v| objs.push(v.generate()));
+        self.impls.iter().for_each(|v| objs.push(v.generate()));
+        self.enums.iter().for_each(|v| objs.push(v.generate()));
         ctx.insert("objs", &objs);
 
         ctx.insert(

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -6,5 +6,6 @@
 /// raw source code.
 pub trait SrcCode {
     /// Given current configuration, give the resulting source code.
+    #[must_use]
     fn generate(&self) -> String;
 }


### PR DESCRIPTION
I have fixed some issues reported by clippy.

Noteworthy changes are
- Use of #[must_use] for SrcCode::generate it doesn't make any sense to generate the code without using it.