### PR TITLE
Add SrcCodeVec trait

### DIFF
--- a/src/gen/enum.rs
+++ b/src/gen/enum.rs
@@ -110,14 +110,7 @@ impl SrcCode for Enum {
         let mut ctx = Context::new();
         ctx.insert("self", &self);
         ctx.insert("generics", &self.generics.generate());
-        ctx.insert(
-            "variants",
-            &self
-                .variants
-                .iter()
-                .map(|v| v.generate())
-                .collect::<Vec<String>>(),
-        );
+        ctx.insert("variants", &self.variants.as_src_vec());
         Tera::one_off(template, &ctx, false).unwrap()
     }
 }

--- a/src/gen/enum.rs
+++ b/src/gen/enum.rs
@@ -110,7 +110,7 @@ impl SrcCode for Enum {
         let mut ctx = Context::new();
         ctx.insert("self", &self);
         ctx.insert("generics", &self.generics.generate());
-        ctx.insert("variants", &self.variants.as_src_vec());
+        ctx.insert("variants", &self.variants.to_src_vec());
         Tera::one_off(template, &ctx, false).unwrap()
     }
 }

--- a/src/gen/function.rs
+++ b/src/gen/function.rs
@@ -11,7 +11,7 @@ use tera::{Context, Tera};
 
 use crate::internal::Annotations;
 use crate::traits::SrcCode;
-use crate::{internal, Generic, Generics};
+use crate::{internal, Generic, Generics, SrcCodeVec};
 
 /// Represents a function or method. Determined if any `Parameter` contains `self`
 #[derive(Default, Serialize, Clone)]
@@ -110,14 +110,7 @@ impl SrcCode for FunctionSignature {
                 .map(|g| g.generic.clone())
                 .collect::<Vec<String>>(),
         );
-        context.insert(
-            "parameters",
-            &self
-                .parameters
-                .iter()
-                .map(|param| param.generate())
-                .collect::<Vec<String>>(),
-        );
+        context.insert("parameters", &self.parameters.as_src_vec());
         Tera::one_off(template, &context, false).unwrap()
     }
 }

--- a/src/gen/function.rs
+++ b/src/gen/function.rs
@@ -110,7 +110,7 @@ impl SrcCode for FunctionSignature {
                 .map(|g| g.generic.clone())
                 .collect::<Vec<String>>(),
         );
-        context.insert("parameters", &self.parameters.as_src_vec());
+        context.insert("parameters", &self.parameters.to_src_vec());
         Tera::one_off(template, &context, false).unwrap()
     }
 }

--- a/src/gen/impl.rs
+++ b/src/gen/impl.rs
@@ -5,7 +5,7 @@
 use serde::Serialize;
 
 use crate::traits::SrcCode;
-use crate::{internal, AssociatedTypeDefinition, Function, Generic, Generics, Trait};
+use crate::{internal, AssociatedTypeDefinition, Function, Generic, Generics, SrcCodeVec, Trait};
 use tera::{Context, Tera};
 
 /// Represents an `impl` block
@@ -89,22 +89,8 @@ impl SrcCode for Impl {
                 .map(|g| g.generic.clone())
                 .collect::<Vec<String>>(),
         );
-        context.insert(
-            "functions",
-            &self
-                .functions
-                .iter()
-                .map(|f| f.generate())
-                .collect::<Vec<String>>(),
-        );
-        context.insert(
-            "associated_types",
-            &self
-                .associated_types
-                .iter()
-                .map(|a| a.generate())
-                .collect::<Vec<String>>(),
-        );
+        context.insert("functions", &self.functions.as_src_vec());
+        context.insert("associated_types", &self.associated_types.as_src_vec());
         Tera::one_off(template, &context, false).unwrap()
     }
 }

--- a/src/gen/impl.rs
+++ b/src/gen/impl.rs
@@ -89,8 +89,8 @@ impl SrcCode for Impl {
                 .map(|g| g.generic.clone())
                 .collect::<Vec<String>>(),
         );
-        context.insert("functions", &self.functions.as_src_vec());
-        context.insert("associated_types", &self.associated_types.as_src_vec());
+        context.insert("functions", &self.functions.to_src_vec());
+        context.insert("associated_types", &self.associated_types.to_src_vec());
         Tera::one_off(template, &context, false).unwrap()
     }
 }

--- a/src/gen/module.rs
+++ b/src/gen/module.rs
@@ -164,7 +164,7 @@ impl SrcCode for Module {
         self.enums.iter().for_each(|v| objs.push(v.generate()));
         ctx.insert("objs", &objs);
 
-        ctx.insert("submodules", &self.sub_modules.as_src_vec());
+        ctx.insert("submodules", &self.sub_modules.to_src_vec());
         Tera::one_off(template, &ctx, false).unwrap()
     }
 }

--- a/src/gen/module.rs
+++ b/src/gen/module.rs
@@ -164,14 +164,7 @@ impl SrcCode for Module {
         self.enums.iter().for_each(|v| objs.push(v.generate()));
         ctx.insert("objs", &objs);
 
-        ctx.insert(
-            "submodules",
-            &self
-                .sub_modules
-                .iter()
-                .map(|m| m.generate())
-                .collect::<Vec<String>>(),
-        );
+        ctx.insert("submodules", &self.sub_modules.as_src_vec());
         Tera::one_off(template, &ctx, false).unwrap()
     }
 }

--- a/src/gen/struct.rs
+++ b/src/gen/struct.rs
@@ -64,7 +64,7 @@ impl SrcCode for Struct {
         "#;
         let mut context = Context::new();
         context.insert("struct", &self);
-        context.insert("fields", &self.fields.as_src_vec());
+        context.insert("fields", &self.fields.to_src_vec());
         context.insert("generics", &self.generics.generate());
         Tera::one_off(template, &context, false).unwrap()
     }

--- a/src/gen/struct.rs
+++ b/src/gen/struct.rs
@@ -64,13 +64,7 @@ impl SrcCode for Struct {
         "#;
         let mut context = Context::new();
         context.insert("struct", &self);
-
-        let fields = self
-            .fields
-            .iter()
-            .map(|f| f.generate())
-            .collect::<Vec<String>>();
-        context.insert("fields", &fields);
+        context.insert("fields", &self.fields.as_src_vec());
         context.insert("generics", &self.generics.generate());
         Tera::one_off(template, &context, false).unwrap()
     }

--- a/src/gen/trait.rs
+++ b/src/gen/trait.rs
@@ -84,8 +84,8 @@ impl SrcCode for Trait {
         "#;
         let mut context = Context::new();
         context.insert("self", &self);
-        context.insert("signatures", &self.signatures.as_src_vec());
-        context.insert("associated_types", &self.associated_types.as_src_vec());
+        context.insert("signatures", &self.signatures.to_src_vec());
+        context.insert("associated_types", &self.associated_types.to_src_vec());
         context.insert("has_generics", &!self.generics.is_empty());
         context.insert("generic_bounds", &self.generics.generate());
         Tera::one_off(template, &context, false).unwrap()

--- a/src/gen/trait.rs
+++ b/src/gen/trait.rs
@@ -5,7 +5,9 @@
 use serde::Serialize;
 
 use crate::traits::SrcCode;
-use crate::{internal, AssociatedTypeDeclaration, FunctionSignature, Generic, Generics};
+use crate::{
+    internal, AssociatedTypeDeclaration, FunctionSignature, Generic, Generics, SrcCodeVec,
+};
 use tera::{Context, Tera};
 
 /// Represents a `trait` block.
@@ -82,22 +84,8 @@ impl SrcCode for Trait {
         "#;
         let mut context = Context::new();
         context.insert("self", &self);
-        context.insert(
-            "signatures",
-            &self
-                .signatures
-                .iter()
-                .map(|s| s.generate())
-                .collect::<Vec<String>>(),
-        );
-        context.insert(
-            "associated_types",
-            &self
-                .associated_types
-                .iter()
-                .map(|t| t.generate())
-                .collect::<Vec<String>>(),
-        );
+        context.insert("signatures", &self.signatures.as_src_vec());
+        context.insert("associated_types", &self.associated_types.as_src_vec());
         context.insert("has_generics", &!self.generics.is_empty());
         context.insert("generic_bounds", &self.generics.generate());
         Tera::one_off(template, &context, false).unwrap()

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -30,6 +30,6 @@ pub trait SrcCodeVec {
 
 impl<T: SrcCode> SrcCodeVec for Vec<T> {
     fn as_src_vec(&self) -> Vec<String> {
-        self.iter().map(|v| v.generate()).collect()
+        self.iter().map(SrcCode::generate).collect()
     }
 }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -25,11 +25,11 @@ pub trait SrcCode {
 /// Trait to help collecting `Vec<impl SrcCode>` into `Vec<String>` via `.generate()`
 pub trait SrcCodeVec {
     /// Convert the current `Vec<impl SrcCode>` into `Vec<String>`
-    fn as_src_vec(&self) -> Vec<String>;
+    fn to_src_vec(&self) -> Vec<String>;
 }
 
 impl<T: SrcCode> SrcCodeVec for Vec<T> {
-    fn as_src_vec(&self) -> Vec<String> {
+    fn to_src_vec(&self) -> Vec<String> {
         self.iter().map(SrcCode::generate).collect()
     }
 }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -21,3 +21,15 @@ pub trait SrcCode {
     #[must_use]
     fn generate(&self) -> String;
 }
+
+/// Trait to help collecting `Vec<impl SrcCode>` into `Vec<String>` via `.generate()`
+pub trait SrcCodeVec {
+    /// Convert the current `Vec<impl SrcCode>` into `Vec<String>`
+    fn as_src_vec(&self) -> Vec<String>;
+}
+
+impl<T: SrcCode> SrcCodeVec for Vec<T> {
+    fn as_src_vec(&self) -> Vec<String> {
+        self.iter().map(|v| v.generate()).collect()
+    }
+}


### PR DESCRIPTION
Convert collection of `Vec<impl SrcCode>` into `Vec<String>` using `.generate()`

@DarkDrek do we want this? Feel like writing the `iter().map(|v| v.generate()).collect::<Vec<String>>()` was getting a bit repetitive during the generation parts.