### PR TITLE
Remove pub crate refs

### DIFF
--- a/src/gen/associated_types.rs
+++ b/src/gen/associated_types.rs
@@ -12,8 +12,8 @@ use crate::traits::SrcCode;
 /// Represent the declaration of a associated type in a trait
 #[derive(Serialize, Deserialize, Default, Clone)]
 pub struct AssociatedTypeDeclaration {
-    pub(crate) name: String,
-    pub(crate) traits: Vec<String>,
+    name: String,
+    traits: Vec<String>,
     annotations: Vec<String>,
 }
 
@@ -56,8 +56,8 @@ impl SrcCode for AssociatedTypeDeclaration {
 /// Represent the definition of a associated type in a trait implementation
 #[derive(Serialize, Deserialize, Default, Clone)]
 pub struct AssociatedTypeDefinition {
-    pub(crate) name: String,
-    pub(crate) implementer: String,
+    name: String,
+    implementer: String,
     annotations: Vec<String>,
 }
 

--- a/src/gen/enum.rs
+++ b/src/gen/enum.rs
@@ -35,7 +35,7 @@ use tera::{Context, Tera};
 #[derive(Default, Serialize, Clone)]
 pub struct Enum {
     name: String,
-    generics: Generics,
+    generics: Vec<Generic>,
     is_pub: bool,
     variants: Vec<Variant>,
 }
@@ -93,8 +93,11 @@ impl SrcCode for Variant {
 }
 
 impl internal::Generics for Enum {
-    fn generics(&mut self) -> &mut Vec<Generic> {
-        self.generics.generics()
+    fn generics_mut(&mut self) -> &mut Vec<Generic> {
+        &mut self.generics
+    }
+    fn generics(&self) -> &[Generic] {
+        self.generics.as_slice()
     }
 }
 

--- a/src/gen/function.rs
+++ b/src/gen/function.rs
@@ -107,7 +107,7 @@ impl SrcCode for FunctionSignature {
                 .generics
                 .generics
                 .iter()
-                .map(|g| g.generic())
+                .map(|g| g.name())
                 .collect::<Vec<&str>>(),
         );
         context.insert("parameters", &self.parameters.to_src_vec());

--- a/src/gen/function.rs
+++ b/src/gen/function.rs
@@ -107,8 +107,8 @@ impl SrcCode for FunctionSignature {
                 .generics
                 .generics
                 .iter()
-                .map(|g| g.generic.clone())
-                .collect::<Vec<String>>(),
+                .map(|g| g.generic())
+                .collect::<Vec<&str>>(),
         );
         context.insert("parameters", &self.parameters.to_src_vec());
         Tera::one_off(template, &context, false).unwrap()

--- a/src/gen/function.rs
+++ b/src/gen/function.rs
@@ -9,9 +9,9 @@
 use serde::Serialize;
 use tera::{Context, Tera};
 
-use crate::internal::Annotations;
+use crate::internal::{Annotations, Generics};
 use crate::traits::SrcCode;
-use crate::{internal, Generic, Generics, SrcCodeVec};
+use crate::{internal, Generic, SrcCodeVec};
 
 /// Represents a function or method. Determined if any `Parameter` contains `self`
 #[derive(Default, Serialize, Clone)]
@@ -27,7 +27,7 @@ pub struct FunctionSignature {
     is_pub: bool,
     is_async: bool,
     parameters: Vec<Parameter>,
-    generics: Generics,
+    generics: Vec<Generic>,
     return_ty: Option<String>,
     annotations: Vec<String>,
 }
@@ -79,8 +79,11 @@ impl internal::Annotations for FunctionSignature {
 }
 
 impl internal::Generics for FunctionSignature {
-    fn generics(&mut self) -> &mut Vec<Generic> {
-        self.generics.generics()
+    fn generics_mut(&mut self) -> &mut Vec<Generic> {
+        &mut self.generics
+    }
+    fn generics(&self) -> &[Generic] {
+        self.generics.as_slice()
     }
 }
 
@@ -91,7 +94,7 @@ impl SrcCode for FunctionSignature {
         ") }}
         {% if self.is_pub %}pub {% endif %}{% if self.is_async %}async {% endif %}fn {{ self.name }}{% if has_generics %}<{{ generic_keys | join(sep=", ") }}>{% endif %}({{ parameters | join(sep=", ") }}) -> {{ return_ty }}{% if has_generics %}
             where
-                {% for generic in generics %}{{ generic.generic }}: {{ generic.traits | join(sep=" + ") }},
+                {% for generic in generics %}{{ generic.name }}: {{ generic.traits | join(sep=" + ") }},
                 {% endfor %}{% endif %}"#;
         let mut context = Context::new();
         context.insert("self", &self);
@@ -99,13 +102,12 @@ impl SrcCode for FunctionSignature {
             "return_ty",
             &self.return_ty.as_ref().unwrap_or(&"()".to_string()),
         );
-        context.insert("has_generics", &!self.generics.is_empty());
-        context.insert("generics", &self.generics.generics);
+        context.insert("has_generics", &!self.generics().is_empty());
+        context.insert("generics", &self.generics());
         context.insert(
             "generic_keys",
             &self
-                .generics
-                .generics
+                .generics()
                 .iter()
                 .map(|g| g.name())
                 .collect::<Vec<&str>>(),
@@ -188,8 +190,11 @@ impl internal::InnerAndOuterAnnotations for Function {
 }
 
 impl internal::Generics for Function {
-    fn generics(&mut self) -> &mut Vec<Generic> {
-        self.signature.generics.generics()
+    fn generics_mut(&mut self) -> &mut Vec<Generic> {
+        &mut self.signature.generics
+    }
+    fn generics(&self) -> &[Generic] {
+        self.signature.generics.as_slice()
     }
 }
 

--- a/src/gen/generics.rs
+++ b/src/gen/generics.rs
@@ -38,53 +38,20 @@ impl internal::TraitBounds for Generic {
     }
 }
 
-/// Represent a collection of trait bounds
-#[derive(Serialize, Deserialize, Default, Clone)]
-pub struct Generics {
-    pub(crate) generics: Vec<Generic>,
-}
-
-impl internal::Generics for Generics {
-    fn generics(&mut self) -> &mut Vec<Generic> {
-        &mut self.generics
-    }
-}
-
-impl Generics {
-    /// Create a new collection of `Generic`s.
-    pub fn new(generics: Vec<Generic>) -> Self {
-        Self { generics }
-    }
-
-    /// Check how many generics are held here
-    pub fn len(&self) -> usize {
-        self.generics.len()
-    }
-
-    /// Determine if it doesn't have any generics.
-    pub fn is_empty(&self) -> bool {
-        self.len() == 0
-    }
-}
-
-impl SrcCode for Generics {
+impl SrcCode for Vec<Generic> {
     fn generate(&self) -> String {
-        if !self.generics.is_empty() {
+        if !self.is_empty() {
             let template = r#"<{{ generic_keys | join(sep=", ") }}>
                 where
-                    {% for generic in generics %}{{ generic.generic }}: {{ generic.traits | join(sep=" + ") }},
+                    {% for generic in generics %}{{ generic.name }}: {{ generic.traits | join(sep=" + ") }},
                     {% endfor %}
             "#;
             let mut context = Context::new();
             context.insert(
                 "generic_keys",
-                &self
-                    .generics
-                    .iter()
-                    .map(|g| g.name())
-                    .collect::<Vec<&str>>(),
+                &self.iter().map(|g| g.name()).collect::<Vec<&str>>(),
             );
-            context.insert("generics", &self.generics);
+            context.insert("generics", &self);
             Tera::one_off(template, &context, false).unwrap()
         } else {
             "".to_string()

--- a/src/gen/generics.rs
+++ b/src/gen/generics.rs
@@ -13,22 +13,22 @@ use crate::traits::SrcCode;
 /// Represent a single trait bound
 #[derive(Serialize, Deserialize, Default, Clone)]
 pub struct Generic {
-    generic: String,
+    name: String,
     traits: Vec<String>,
 }
 
 impl Generic {
     /// Create a new `Generic`
-    pub fn new(id: impl ToString) -> Self {
+    pub fn new(name: impl ToString) -> Self {
         Self {
-            generic: id.to_string(),
+            name: name.to_string(),
             ..Self::default()
         }
     }
 
     /// Get the name of the generic
-    pub fn generic(&self) -> &str {
-        self.generic.as_str()
+    pub fn name(&self) -> &str {
+        self.name.as_str()
     }
 }
 
@@ -81,8 +81,8 @@ impl SrcCode for Generics {
                 &self
                     .generics
                     .iter()
-                    .map(|g| g.generic.clone())
-                    .collect::<Vec<String>>(),
+                    .map(|g| g.name())
+                    .collect::<Vec<&str>>(),
             );
             context.insert("generics", &self.generics);
             Tera::one_off(template, &context, false).unwrap()

--- a/src/gen/generics.rs
+++ b/src/gen/generics.rs
@@ -14,7 +14,7 @@ use crate::traits::SrcCode;
 #[derive(Serialize, Deserialize, Default, Clone)]
 pub struct Generic {
     pub(crate) generic: String,
-    pub(crate) traits: Vec<String>,
+    traits: Vec<String>,
 }
 
 impl Generic {

--- a/src/gen/generics.rs
+++ b/src/gen/generics.rs
@@ -13,7 +13,7 @@ use crate::traits::SrcCode;
 /// Represent a single trait bound
 #[derive(Serialize, Deserialize, Default, Clone)]
 pub struct Generic {
-    pub(crate) generic: String,
+    generic: String,
     traits: Vec<String>,
 }
 
@@ -24,6 +24,11 @@ impl Generic {
             generic: id.to_string(),
             ..Self::default()
         }
+    }
+
+    /// Get the name of the generic
+    pub fn generic(&self) -> &str {
+        self.generic.as_str()
     }
 }
 

--- a/src/gen/impl.rs
+++ b/src/gen/impl.rs
@@ -83,8 +83,8 @@ impl SrcCode for Impl {
                 .generics
                 .generics
                 .iter()
-                .map(|g| g.generic.clone())
-                .collect::<Vec<String>>(),
+                .map(|g| g.generic())
+                .collect::<Vec<&str>>(),
         );
         context.insert("functions", &self.functions.to_src_vec());
         context.insert("associated_types", &self.associated_types.to_src_vec());

--- a/src/gen/impl.rs
+++ b/src/gen/impl.rs
@@ -83,7 +83,7 @@ impl SrcCode for Impl {
                 .generics
                 .generics
                 .iter()
-                .map(|g| g.generic())
+                .map(|g| g.name())
                 .collect::<Vec<&str>>(),
         );
         context.insert("functions", &self.functions.to_src_vec());

--- a/src/gen/impl.rs
+++ b/src/gen/impl.rs
@@ -4,14 +4,15 @@
 
 use serde::Serialize;
 
+use crate::internal::Generics;
 use crate::traits::SrcCode;
-use crate::{internal, AssociatedTypeDefinition, Function, Generic, Generics, SrcCodeVec, Trait};
+use crate::{internal, AssociatedTypeDefinition, Function, Generic, SrcCodeVec, Trait};
 use tera::{Context, Tera};
 
 /// Represents an `impl` block
 #[derive(Serialize, Default, Clone)]
 pub struct Impl {
-    generics: Generics,
+    generics: Vec<Generic>,
     impl_trait: Option<Trait>,
     functions: Vec<Function>,
     obj_name: String,
@@ -47,8 +48,11 @@ impl Impl {
 }
 
 impl internal::Generics for Impl {
-    fn generics(&mut self) -> &mut Vec<Generic> {
-        self.generics.generics()
+    fn generics_mut(&mut self) -> &mut Vec<Generic> {
+        &mut self.generics
+    }
+    fn generics(&self) -> &[Generic] {
+        self.generics.as_slice()
     }
 }
 
@@ -58,7 +62,7 @@ impl SrcCode for Impl {
             impl{% if has_generics %}<{{ generic_keys | join(sep=", ") }}>{% endif %} {% if has_trait %}{{ trait_name }} for {% endif %}{{ self.obj_name }}{% if has_generics %}<{{ generic_keys | join(sep=", ") }}>{% endif %}
                 {% if has_generics %}
                 where
-                    {% for generic in generics %}{{ generic.generic }}: {{ generic.traits | join(sep=" + ") }},
+                    {% for generic in generics %}{{ generic.name }}: {{ generic.traits | join(sep=" + ") }},
                     {% endfor %}
                 {% endif %}
             {
@@ -75,13 +79,12 @@ impl SrcCode for Impl {
             "trait_name",
             &self.impl_trait.as_ref().map_or_else(|| "", |t| t.name()),
         );
-        context.insert("has_generics", &!self.generics.is_empty());
-        context.insert("generics", &self.generics.generics);
+        context.insert("has_generics", &!self.generics().is_empty());
+        context.insert("generics", &self.generics());
         context.insert(
             "generic_keys",
             &self
-                .generics
-                .generics
+                .generics()
                 .iter()
                 .map(|g| g.name())
                 .collect::<Vec<&str>>(),

--- a/src/gen/impl.rs
+++ b/src/gen/impl.rs
@@ -73,10 +73,7 @@ impl SrcCode for Impl {
         context.insert("has_trait", &self.impl_trait.is_some());
         context.insert(
             "trait_name",
-            &self
-                .impl_trait
-                .as_ref()
-                .map_or_else(|| "".to_string(), |t| t.name.clone()),
+            &self.impl_trait.as_ref().map_or_else(|| "", |t| t.name()),
         );
         context.insert("has_generics", &!self.generics.is_empty());
         context.insert("generics", &self.generics.generics);

--- a/src/gen/struct.rs
+++ b/src/gen/struct.rs
@@ -14,7 +14,7 @@ pub struct Struct {
     is_pub: bool,
     name: String,
     fields: Vec<Field>,
-    generics: Generics,
+    generics: Vec<Generic>,
     docs: Vec<String>,
 }
 
@@ -41,8 +41,11 @@ impl internal::Fields for Struct {
 }
 
 impl internal::Generics for Struct {
-    fn generics(&mut self) -> &mut Vec<Generic> {
-        self.generics.generics()
+    fn generics_mut(&mut self) -> &mut Vec<Generic> {
+        &mut self.generics
+    }
+    fn generics(&self) -> &[Generic] {
+        self.generics.as_slice()
     }
 }
 

--- a/src/gen/trait.rs
+++ b/src/gen/trait.rs
@@ -33,7 +33,7 @@ use tera::{Context, Tera};
 #[derive(Serialize, Default, Clone)]
 pub struct Trait {
     pub(crate) name: String,
-    pub(crate) is_pub: bool,
+    is_pub: bool,
     generics: Generics,
     signatures: Vec<FunctionSignature>,
     associated_types: Vec<AssociatedTypeDeclaration>,

--- a/src/gen/trait.rs
+++ b/src/gen/trait.rs
@@ -5,9 +5,7 @@
 use serde::Serialize;
 
 use crate::traits::SrcCode;
-use crate::{
-    internal, AssociatedTypeDeclaration, FunctionSignature, Generic, Generics, SrcCodeVec,
-};
+use crate::{internal, AssociatedTypeDeclaration, FunctionSignature, Generic, SrcCodeVec};
 use tera::{Context, Tera};
 
 /// Represents a `trait` block.
@@ -34,7 +32,7 @@ use tera::{Context, Tera};
 pub struct Trait {
     name: String,
     is_pub: bool,
-    generics: Generics,
+    generics: Vec<Generic>,
     signatures: Vec<FunctionSignature>,
     associated_types: Vec<AssociatedTypeDeclaration>,
 }
@@ -73,8 +71,11 @@ impl Trait {
 }
 
 impl internal::Generics for Trait {
-    fn generics(&mut self) -> &mut Vec<Generic> {
-        self.generics.generics()
+    fn generics_mut(&mut self) -> &mut Vec<Generic> {
+        &mut self.generics
+    }
+    fn generics(&self) -> &[Generic] {
+        self.generics.as_slice()
     }
 }
 

--- a/src/gen/trait.rs
+++ b/src/gen/trait.rs
@@ -32,7 +32,7 @@ use tera::{Context, Tera};
 /// ```
 #[derive(Serialize, Default, Clone)]
 pub struct Trait {
-    pub(crate) name: String,
+    name: String,
     is_pub: bool,
     generics: Generics,
     signatures: Vec<FunctionSignature>,
@@ -46,6 +46,11 @@ impl Trait {
             name: name.to_string(),
             ..Self::default()
         }
+    }
+
+    /// Get the trait name
+    pub fn name(&self) -> &str {
+        self.name.as_str()
     }
 
     /// Add a new signature requirement to this trait.

--- a/src/internal/mod.rs
+++ b/src/internal/mod.rs
@@ -22,7 +22,8 @@ pub trait Fields {
 /// Internal trait to get access to the container storing the generics.
 /// Used for the generic implementation of `GenericExt`
 pub trait Generics {
-    fn generics(&mut self) -> &mut Vec<Generic>;
+    fn generics_mut(&mut self) -> &mut Vec<Generic>;
+    fn generics(&self) -> &[Generic];
 }
 
 /// Internal trait to get access to the container storing the trait bounds.

--- a/src/traits/generics.rs
+++ b/src/traits/generics.rs
@@ -17,13 +17,13 @@ pub trait GenericExt {
 impl<T: Generics> GenericExt for T {
     /// Add a single generic.
     fn add_generic(&mut self, generic: Generic) -> &mut Self {
-        self.generics().push(generic);
+        self.generics_mut().push(generic);
         self
     }
 
     /// Add multiple generics at once.
     fn add_generics<'a>(&mut self, generics: impl IntoIterator<Item = &'a Generic>) -> &mut Self {
-        self.generics()
+        self.generics_mut()
             .extend(generics.into_iter().map(ToOwned::to_owned));
         self
     }


### PR DESCRIPTION
Will close #31 

Removes use of `pub(crate)`. One note is that when removing `pub(crate) generics: Generics` it became apparent `Generics` is inconsistent, and better represented as `Vec<Generic>` as we do with other collections. And therefore indirectly caused a need to add `traits::Generics::generics_mut/generics` 

Additionally, the field `Generic.generic` wasn't consistent either so renamed it to `Generic.name`