### PR TITLE
Support pushing src code into function bodies

### DIFF
--- a/src/gen/function.rs
+++ b/src/gen/function.rs
@@ -121,7 +121,7 @@ impl SrcCode for FunctionSignature {
 /// Represents the function/method's body
 #[derive(Default, Serialize, Clone)]
 pub struct FunctionBody {
-    body: String,
+    body: Vec<String>,
     attributes: Vec<Attribute>,
 }
 
@@ -136,7 +136,8 @@ impl SrcCode for FunctionBody {
         let template = r#"
             {{ attributes | join(sep="
             ") }}
-            {{ self.body }}
+            {{ self.body | join(sep="
+            ") }}
         "#;
         let mut ctx = Context::new();
         ctx.insert("self", &self);
@@ -181,8 +182,13 @@ impl Function {
         self
     }
     /// Set the body of the function, this should be valid Rust source code syntax.
-    pub fn set_body(&mut self, body: impl ToString) -> &mut Self {
-        self.body.body = body.to_string();
+    pub fn set_body(&mut self, body: impl SrcCode) -> &mut Self {
+        self.body.body = vec![body.generate()];
+        self
+    }
+    /// Push anything which implements `SrcCode` into the body of the function
+    pub fn push_into_body(&mut self, src: impl SrcCode) -> &mut Self {
+        self.body.body.push(src.generate());
         self
     }
     /// Add an attribute before the body of the function

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -33,3 +33,15 @@ impl<T: SrcCode> SrcCodeVec for Vec<T> {
         self.iter().map(SrcCode::generate).collect()
     }
 }
+
+impl<'a> SrcCode for &'a str {
+    fn generate(&self) -> String {
+        self.to_string()
+    }
+}
+
+impl SrcCode for String {
+    fn generate(&self) -> String {
+        self.clone()
+    }
+}

--- a/tests/function_gen_test.rs
+++ b/tests/function_gen_test.rs
@@ -160,3 +160,25 @@ fn function_with_attributes() {
     println!("{}", &src_code);
     assert_eq!(norm_whitespace(expected), norm_whitespace(&src_code));
 }
+
+#[test]
+fn function_push_into_body() {
+    let function = Function::new("foo")
+        .set_body("// Body")
+        .push_into_body("// First line")
+        .push_into_body("// Second line")
+        .to_owned();
+
+    let expected = r#"
+        fn foo() -> ()
+        {
+            // Body
+            // First line
+            // Second line
+        }
+    "#;
+
+    let src_code = function.generate_and_verify();
+    println!("{}", &src_code);
+    assert_eq!(norm_whitespace(expected), norm_whitespace(&src_code));
+}


### PR DESCRIPTION
Will close #23 

Only implemented it for `Function.body` as it didn't seem that practical for `Module` or anything else? :man_shrugging: 